### PR TITLE
Fix Reviews Modal Issues

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -1,4 +1,4 @@
-import 'webext-dynamic-content-scripts';
+import 'webext-dynamic-content-scripts'
 import addDomainPermissionToggle from 'webext-domain-permission-toggle'
 
 // Allow the extension to be run on custom domains e.g. GitHub enterprise

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,7 @@
 import './style.css'
 import Giphy from './lib/giphy'
 import GiphyToolbarItem from './components/giphy-toolbar-item'
-import {insert} from 'text-field-edit'
+import { insert } from 'text-field-edit'
 import LoadingIndicator from './components/loading-indicator'
 import Masonry from 'masonry-layout'
 import debounce from 'debounce-fn'
@@ -77,6 +77,11 @@ function addToolbarButton () {
     'form:not(.ghg-has-giphy-field) markdown-toolbar'
   )) {
     const form = toolbar.closest('form')
+    const reviewChangesModal = toolbar.closest('#review-changes-modal .SelectMenu-modal')
+
+    if (reviewChangesModal !== null) {
+      reviewChangesModal.classList.add('ghg-in-review-changes-modal')
+    }
 
     // Observe the toolbars without the giphy field, add
     // the toolbar item to any new toolbars.

--- a/src/style.css
+++ b/src/style.css
@@ -22,3 +22,7 @@
   background-repeat: no-repeat;
   width: 144.45px;
 }
+
+.ghg-in-review-changes-modal {
+  width: 678px !important;
+}


### PR DESCRIPTION
## Summary

![giphy-review-collapse](https://user-images.githubusercontent.com/5964236/95818501-f8f7ac00-0d5e-11eb-8ba5-2ba7fff310b9.gif)

Hey, thanks for the great Browser extension! I noticed that the `GIF` toolbar button wraps to a new line in the Github "Reviews" modal. When the `GIF` button is clicked the Giphy popover shows cropped in the modal, see GIF above for reference. 

Sadly this makes it difficult to add GIFs when reviewing a Pull Request. I'm not sure if this affects all GitHub users or relates to a beta UI change.


## Why this happens?

Runtime GitHub JS adds an element style of `width: 640px` to the reviews modal, which causes the toolbar to wrap as there is not enough space, this also affects the Giphy popover causing it to overflow outside of the modal.

<img width="727" alt="Screen Shot 2020-10-13 at 14 27 20" src="https://user-images.githubusercontent.com/5964236/95819131-56402d00-0d60-11eb-975b-64873e73b53c.png">


## The Fix

I've opted for a simpler fix which identifies when the toolbar is a child of the Review Changes Modal and adds the class `ghg-in-reviews-modal`.

This CSS class overrides the width of the reviews modal to accommodate the GIF toolbar and popover:
![giphy-review-fix](https://user-images.githubusercontent.com/5964236/95819269-8e477000-0d60-11eb-87c6-dd7399f2fae5.gif)
