### PR TITLE
Fix masonry layout regression on modal re-open

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -53,7 +53,7 @@ async function watchGiphyModals (element) {
     }
   } else {
     setTimeout(
-      new Masonry(
+      () => new Masonry(
         resultsContainer,
         {
           itemSelector: '.ghg-giphy-results div',


### PR DESCRIPTION
## Bug

![bugggg](https://user-images.githubusercontent.com/5964236/96471376-3d58df80-126a-11eb-9a06-5af0df84a07d.gif)

## Fix

Needed to ensure the Masonry object construction was in a callback so it's initialised after the modal is opened 

![](https://media4.giphy.com/media/mnqeovjKUhujvHSbKE/giphy.gif)
