### PR TITLE
Fix review modal overflow display

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -78,9 +78,14 @@ function addToolbarButton () {
   )) {
     const form = toolbar.closest('form')
     const reviewChangesModal = toolbar.closest('#review-changes-modal .SelectMenu-modal')
+    const reviewChangesList = toolbar.closest('#review-changes-modal .SelectMenu-list')
 
     if (reviewChangesModal !== null) {
       reviewChangesModal.classList.add('ghg-in-review-changes-modal')
+    }
+
+    if (reviewChangesList !== null) {
+      reviewChangesList.classList.add('ghg-in-review-changes-list')
     }
 
     // Observe the toolbars without the giphy field, add

--- a/src/style.css
+++ b/src/style.css
@@ -5,7 +5,7 @@
 }
 
 .ghg-giphy-results::-webkit-scrollbar {
-    display: none;
+  display: none;
 }
 
 .ghg-giphy-results img {
@@ -17,12 +17,21 @@
 }
 
 .ghg-powered-by-giphy {
-  background: url('chrome-extension://__MSG_@@extension_id__/images/powered-by-giphy.png');
+  background: url("chrome-extension://__MSG_@@extension_id__/images/powered-by-giphy.png");
   background-size: auto 16px;
   background-repeat: no-repeat;
   width: 144.45px;
 }
 
 .ghg-in-review-changes-modal {
+  /* Fixes the GIF button dropping to a new line in the review modal */
   width: 678px !important;
+  /* Fixes the GIF dropdown being hidden by the review modal's overflow */
+  overflow: unset !important;
+}
+
+/* Fixes the GIF dropdown being hidden by the review modal's overflow */
+.ghg-in-review-changes-list {
+  contain: unset !important;
+  overflow: unset !important;
 }


### PR DESCRIPTION
Recently GitHub have made some style changes to their review modal, this caused an issue where the GIF toolbar button dropped to a new line: https://github.com/N1ck/gifs-for-github/pull/18.

It has also caused an issue with any tooltips or dropdowns inside the review modal (not just GIFs for GitHub, but also their own)

e.g.

<img src="https://user-images.githubusercontent.com/1018141/96931389-bc277400-1519-11eb-801f-5bca46ec507e.gif" width="600">

To workaround this issue for the time being I have just removed some of the CSS properties causing the overflow to be hidden:

<img src="https://user-images.githubusercontent.com/1018141/96931691-2e985400-151a-11eb-935f-a707fc953415.gif" width="600">

