### PR TITLE
Fix css selector to append gif toolbar button back

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -100,7 +100,7 @@ function addToolbarButton() {
     // the toolbar item to any new toolbars.
     observeEl(toolbar, () => {
       let toolbarGroup = select.all(
-        '.toolbar-commenting > :not([class*="--hidden"]):not(button)',
+        '.ActionBar-item-container > :not([class*="--hidden"]):not(button)',
         toolbar
       )
       toolbarGroup = toolbarGroup[toolbarGroup.length - 1]
@@ -141,7 +141,7 @@ function addToolbarButton() {
  * Watches for comments that might be dynamically added, then adds the button the the WYSIWYG when they are.
  */
 function observeDiscussion() {
-  observe('md-task-list', () => addToolbarButton())
+  observe('markdown-toolbar', () => addToolbarButton())
 }
 
 /**

--- a/src/main.js
+++ b/src/main.js
@@ -100,10 +100,9 @@ function addToolbarButton() {
     // the toolbar item to any new toolbars.
     observeEl(toolbar, () => {
       let toolbarGroup = select.all(
-        '.ActionBar-item-container > :not([class*="--hidden"]):not(button)',
+      const toolbarGroup = select('.ActionBar-item-container', toolbar)
         toolbar
       )
-      toolbarGroup = toolbarGroup[toolbarGroup.length - 1]
 
       if (toolbarGroup) {
         // Append the Giphy button to the toolbar


### PR DESCRIPTION
Hello @N1ck,  this is just an attempt from me trying to fix this extension. Vend is not the same without it 

Github just rolled out a bunch of frontend change and it broke this extension


Proof that it works on my machine 

<img width="1197" alt="Screenshot 2023-11-01 at 9 42 46 AM" src="https://github.com/N1ck/gifs-for-github/assets/29682322/1cc75a5b-ccde-487e-8a2d-ed72bbfd91da">

***PS*** I don't know what I'm doing so all feedback are welcomed 😅 