### PR TITLE
[BugFix] Toolbar alignment causing modal overflow

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -59,3 +59,23 @@
 [class*="prc-Overlay-Overlay"] {
   overflow: visible !important;
 }
+
+/*
+ * Override for GitHub's toolbar alignment bug
+ *
+ * When the review modal gets a vertical scrollbar, GitHub's media query
+ * incorrectly applies justify-content: flex-end to the toolbar, causing misalignment
+ * of toolbar items.
+ *
+ * GitHub's problematic rule:
+ * @media (width > 600px) {
+ *     .Toolbar-module__toolbar--TBvFM:last-child {
+ *         justify-content: flex-end;
+ *     }
+ * }
+ *
+ * This override forces the correct alignment when the giphy field is present.
+ */
+.ghg-has-giphy-field [class*="Toolbar-module__toolbar"] {
+  justify-content: flex-end !important
+}


### PR DESCRIPTION
In a recent update, GitHub now has an issue where the alignment of toolbar items change when the container is < 600px. This can be triggered by a vertical overflow 

e.g. (without Gifs for GitHub enabled)
<video src="https://github.com/user-attachments/assets/61ef4173-044f-4815-9f83-7ecfafb02673" />

This impacts the extension because Gifs are hidden from view:
<img width="720" height="620" alt="image" src="https://github.com/user-attachments/assets/a742eb9e-c78e-4148-bb2f-9cbb43fc196c" />

## Fix

In this PR, I'm specifically overriding this behaviour for the toolbar with the GIF button attached.



<img src="https://media0.giphy.com/media/v1.Y2lkPWJkM2VhNTdleXdyNTU0dXk5ejVyNTVwaWc4d28zaGwxM2E1eDZycGk2N3M3ZTdpaCZlcD12MV9naWZzX3NlYXJjaCZjdD1n/lkzQSklzkfqUzSd4j3/giphy-downsized-medium.gif"/>

