### PR TITLE
Fix GIF menu rendering in diff view table rows

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -115,6 +115,13 @@ function addToolbarButton(toolbar) {
     return;
   }
 
+  // Check if the toolbar is inside a table row (e.g., in diff views)
+  const tableRow = toolbar.closest('tr');
+  if (tableRow) {
+    debugLog('Found toolbar inside table row, adding class');
+    tableRow.classList.add('ghg-has-toolbar');
+  }
+
   // Find the toolbar group to add our button to
   const isNewToolbar = toolbar.getAttribute('aria-label') === 'Formatting tools';
   let toolbarGroup;

--- a/src/style.css
+++ b/src/style.css
@@ -61,6 +61,25 @@
 }
 
 /*
+ * Fixes the GIF menu not overflowing the toolbar
+ * Allows the GIF dropdown to be visible outside the toolbar container
+ */
+.ghg-has-giphy-field
+[class*="Toolbar-module__toolbar"][class*="prc-ActionBar-Nav"] {
+  overflow: visible !important;
+}
+
+/*
+ * Fixes the GIF menu appearing below the code diff
+ * When the toolbar is inside a table row (e.g., in PR diff views),
+ * this ensures the GIF dropdown appears above other content
+ */
+.ghg-has-toolbar {
+  position: relative;
+  z-index: 5;
+}
+
+/*
  * Override for GitHub's toolbar alignment bug
  *
  * When the review modal gets a vertical scrollbar, GitHub's media query


### PR DESCRIPTION
Another GitHub markup/styling change, another CSS override!

## Issue:
<img width="780" height="267" alt="image" src="https://github.com/user-attachments/assets/9ab06a40-c33e-4947-9f76-7861442135ad" />


<img src="https://media1.giphy.com/media/v1.Y2lkPWJkM2VhNTdlaDBlNW4xcjZld3M5a2I3azhzOWF5emZ2czl0d3U2aWU1cGR0OG41ZyZlcD12MV9naWZzX3RyZW5kaW5nJmN0PWc/H6cmWzp6LGFvqjidB7/giphy.gif"/>