### PR TITLE
Buttons appearing above dropdown

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -98,3 +98,11 @@
 .ghg-has-giphy-field [class*="Toolbar-module__toolbar"] {
   justify-content: flex-end !important
 }
+
+
+/*
+ * Fixes the close issue / comment buttons appearing above the GIF Menu
+ */
+.ghg-has-giphy-field {
+  z-index: 1;
+}


### PR DESCRIPTION
In a previous PR I fixed a major issue causing the extension to be unusable:
<img width="780" height="267" alt="image" src="https://github.com/user-attachments/assets/9ab06a40-c33e-4947-9f76-7861442135ad" />


This PR fixes a smaller but still very annoying issue, showing the close issue/comment buttons above the GIF dropdown:

<img width="487" height="379" alt="image" src="https://github.com/user-attachments/assets/8aa3eb96-211c-45b4-be54-08b4bcb02e60" />
