### PR TITLE
Fix breaking layout issue with dropdown

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -65,7 +65,7 @@
  * Allows the GIF dropdown to be visible outside the toolbar container
  */
 .ghg-has-giphy-field
-[class*="Toolbar-module__toolbar"][class*="prc-ActionBar-Nav"] {
+[class*="prc-ActionBar-Nav"] {
   overflow: visible !important;
 }
 


### PR DESCRIPTION
The same issue as https://github.com/N1ck/gifs-for-github/pull/98 cropped up again as GitHub changed the layout/classes. 


<img width="749" height="266" alt="image" src="https://github.com/user-attachments/assets/aa118d61-749f-4c4a-b8cf-84e6f665c7af" />

This PR fixes this issue, there is another minor issue where the GIF button appears before saved replies in some scenarios which I will address separately. 


<img src="https://media3.giphy.com/media/v1.Y2lkPWJkM2VhNTdlb2tnZjgzdWl0aWZkNnhmbmc5amVpcXIzaHdsZTVqOHB4N29saHJwOCZlcD12MV9naWZzX3NlYXJjaCZjdD1n/9JLOGsEfPjpR1179HE/giphy.gif"/>