### PR TITLE
Add required host_permissions for Klipy and GIPHY APIs

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -23,6 +23,10 @@
     "activeTab",
     "storage"
   ],
+  "host_permissions": [
+    "https://api.klipy.com/*",
+    "https://api.giphy.com/*"
+  ],
   "optional_host_permissions": [
     "http://*/*",
     "https://*/*",


### PR DESCRIPTION
The Klipy migration removed the api.giphy.com host permission from the manifest but didn't add an equivalent for api.klipy.com.

Restore `host_permissions` for both `api.klipy.com` (default provider) and `api.giphy.com` (optional fallback when the user supplies their own key via the options page) so search works out of the box.