### PR TITLE
Fix content scripts not injecting into newly-permitted domains

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -1,5 +1,7 @@
 import addPermissionToggle from 'webext-permission-toggle';
 import browser from 'webextension-polyfill';
+// Required: automatically injects content scripts into domains granted via webext-permission-toggle
+import 'webext-dynamic-content-scripts';
 
 // Default settings
 const defaultSettings = {

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -21,7 +21,8 @@
   "permissions": [
     "contextMenus",
     "activeTab",
-    "storage"
+    "storage",
+    "scripting"
   ],
   "host_permissions": [
     "https://api.klipy.com/*",


### PR DESCRIPTION
## Problem

Enabling the extension on a custom domain (e.g. GitHub Enterprise on `*.ghe.com`) via the right-click **Enable GIFs for GitHub on this domain** toggle granted the host permission but nothing ever injected the content script there, so the GIF button never appeared.

Fixes #108
